### PR TITLE
Change linker script to ensure HTIF memory is isolated on its own page

### DIFF
--- a/linker.ld
+++ b/linker.ld
@@ -20,9 +20,6 @@ SECTIONS {
 		*(.text)
 	} 
 
-    . = ALIGN(0x1000);
-    .tohost : { *(.tohost) }
-
 	.rodata :  {
 		*(.rodata)
 	}
@@ -38,7 +35,12 @@ SECTIONS {
 		*(.data)
 	}
 
-	.bss (NOLOAD) :  {	
+	// HTIF memory needs to be located on its own page
+	.tohost ALIGN(0x1000) :  {
+		*(.tohost)
+	}
+
+	.bss ALIGN(0x1000) (NOLOAD) :  {
 		__bss_start = .;
 		*(.bss) 
 		*(.sbss) 


### PR DESCRIPTION
Instruction fetches from the HTIF page are not allowed, so there needs to be an additional ALIGN(0x1000) directive after the section to prevent any code from being placed on that page.

on-behalf-of: @ventanamicro <autley@ventanamicro.com>