### PR TITLE
Change extraneous print messages at LOG_INFO level to LOG_DEBUG level

### DIFF
--- a/translation_tests.c
+++ b/translation_tests.c
@@ -254,7 +254,7 @@ bool m_and_hs_using_vs_access(){
     hsvw(vaddr, ((uint32_t)-1));
     val = hlvw(vaddr);
     valu = hlvwu(vaddr);
-    printf("val 0x%llx, valu 0x%llx\n", val, valu);
+    DEBUG("val 0x%llx, valu 0x%llx\n", val, valu);
     TEST_ASSERT("hs hlvw vs hlvwu",
         excpt.triggered == false && val == (-1) && valu == ((uint32_t)-1)
     );
@@ -404,7 +404,7 @@ bool m_and_hs_using_vs_access(){
     );
 
     vaddr = vs_page_base(VSI_GUR);
-    INFO_PRINT(vaddr);
+    DEBUG_PRINT(vaddr);
     TEST_SETUP_EXCEPT();
     val = hlvb(vaddr);
     TEST_ASSERT("hs hlvb on ro 2-stage page successfull",


### PR DESCRIPTION
The two changed lines in this commit were printing at LOG_INFO level, which is the default, but the printed statements broke the formatting of the test result report. This shouldn't be the default behavior, but is okay if the user is running in debug mode.

on-behalf-of: @ventanamicro <autley@ventanamicro.com>