### PR TITLE
Fix incorrect condition for 'vs access to time succeeds' test

### DIFF
--- a/virtual_instruction.c
+++ b/virtual_instruction.c
@@ -104,8 +104,7 @@ bool virtual_instruction() {
     TEST_SETUP_EXCEPT();
     time = CSRR(time);
     TEST_ASSERT("vs access to time casuses succsseful with mcounteren.tm and hcounteren.tm set",
-        excpt.triggered == true &&
-        excpt.cause == CAUSE_ILI
+        excpt.triggered == false
     );
 
     //////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The test for 'VS-mode access to time succeeds with mcounteren.tm and hcounteren.tm set' should PASS when no exception is triggered. It was previously checking for a virtual instruction exception and FAILING on the correct behavior (no exception).

on-behalf-of: @ventanamicro <autley@ventanamicro.com>